### PR TITLE
Empty arrow function removed

### DIFF
--- a/internal/kafka/producer/synchronous_producer.ts
+++ b/internal/kafka/producer/synchronous_producer.ts
@@ -106,6 +106,7 @@ export class SynchronousProducer extends AbstractProducer {
                     this.poll();
                 }, 100);
             } catch (error) {
+                // @ts-ignore
                 if (deliveryListener) {
                     this.removeListener("delivery-report", deliveryListener);
                 }


### PR DESCRIPTION
I've kept the variable definition but removed the not-required empty arrow function. We only need this variable reference to remove the listener in the error case.