### PR TITLE
fix: correct blockNumber field in formatRawReceipt (BB3401672)

### DIFF
--- a/internal/formatters/block_formatter.ts
+++ b/internal/formatters/block_formatter.ts
@@ -34,7 +34,7 @@ export class BlockFormatter {
 
         return this.formatTransactionReceipt({
             ...receipt,
-            blockNumber: utils.hexToNumber(receipt.transactionIndex) as number,
+            blockNumber: utils.hexToNumber(receipt.blockNumber) as number,
             cumulativeGasUsed: utils.hexToNumber(receipt.cumulativeGasUsed) as number,
             transactionIndex: utils.hexToNumber(receipt.transactionIndex) as number,
             gasUsed: utils.hexToNumber(receipt.gasUsed) as number,


### PR DESCRIPTION
## Bug

In `internal/formatters/block_formatter.ts`, `formatRawReceipt()` was using `receipt.transactionIndex` as the source value when converting the `blockNumber` field:

```ts
// Before (wrong)
blockNumber: utils.hexToNumber(receipt.transactionIndex) as number,
```

This means every indexed receipt stored the **transaction's position within the block** as its block number — not the actual block number.

## Impact

- Every receipt indexed by this formatter has a corrupted `blockNumber` value.
- Because `blockNumber` is used to detect chain reorganisations and determine which records to delete/reindex, wrong values here can trigger **mass deletion of valid records** on the next reorg scan, or silently suppress legitimate reorg cleanup.
- The impact scales with indexer uptime — the longer the service has been running against a corrupted dataset, the larger the blast radius of any reorg-triggered sweep.

## Fix

One-line change: replace `receipt.transactionIndex` with `receipt.blockNumber` as the source for the `blockNumber` field.

```ts
// After (correct)
blockNumber: utils.hexToNumber(receipt.blockNumber) as number,
```

The field immediately below it (`transactionIndex`) was and remains correct — it reads from `receipt.transactionIndex`. Only the `blockNumber` line was wrong.

## Verification

- `formatRawReceipt` now correctly maps `receipt.blockNumber → blockNumber` and `receipt.transactionIndex → transactionIndex`.
- No other fields were changed.

Fixes BB3401672.