### PR TITLE
fix(queue): prevent memory leak in Queue.shiftByN

### DIFF
--- a/internal/queue/queue.ts
+++ b/internal/queue/queue.ts
@@ -49,11 +49,13 @@ export class Queue<T> {
 
         this.head = this.head + position - 1;
         const item = this.items[this.head];
-        for (const key in Object.keys(this.items)) {
+        // `for...of` — `for...in Object.keys(...)` iterates array indices, not keys,
+        // and silently leaks entries once `head` exceeds the array length.
+        for (const key of Object.keys(this.items)) {
             const numericKey = parseInt(key);
 
             if (numericKey <= this.head) {
-                delete this.items[key];
+                delete this.items[numericKey];
             }
         }
         this.head++;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maticnetwork/chain-indexer-framework",
-  "version": "1.4.20",
+  "version": "1.4.22",
   "description": "blockchain data indexer",
   "type": "module",
   "exports": {

--- a/tests/queue/queue.test.ts
+++ b/tests/queue/queue.test.ts
@@ -99,4 +99,43 @@ describe("Common Queue class", () => {
         });
     });
 
+    describe("shiftByN", () => {
+        test("Should return the Nth item and advance past the skipped entries", () => {
+            ["a", "b", "c", "d", "e"].forEach(v => queue.enqueue(v));
+            expect(queue.shiftByN(3)).toBe("c");
+            expect(queue.getLength()).toBe(2);
+            expect(queue.front()).toBe("d");
+        });
+
+        test("Should return null when position exceeds queue length", () => {
+            queue.enqueue("a");
+            queue.enqueue("b");
+            expect(queue.shiftByN(5)).toBe(null);
+        });
+
+        test("Should not leak skipped entries after `head` has advanced past the array length", () => {
+            // Reproduces the bug where `for...in Object.keys(...)` iterates array
+            // indices (0..N-1) instead of actual item keys. The failure only appears
+            // once `head` exceeds the current size of the items bag — otherwise the
+            // array indices and actual keys coincidentally overlap and nothing leaks.
+            // Drive `head` forward with single shifts first, then call shiftByN.
+            for (let i = 0; i < 1000; i++) queue.enqueue(`item-${i}`);
+            for (let i = 0; i < 500; i++) queue.shift();
+            // items bag now holds keys 500..999 (500 entries); head=500.
+            queue.shiftByN(200);
+            // head becomes 700 — past the 500-length bag. With the bug, the delete
+            // loop iterates indices 0..499 which don't exist as keys, so entries
+            // 500..699 leak. Logical length is 300; bag should also be 300.
+            expect(queue.getLength()).toBe(300);
+            expect(Object.keys((queue as unknown as { items: Record<string, unknown> }).items)).toHaveLength(queue.getLength());
+        });
+
+        test("Should fully drain internal storage when the queue is empty", () => {
+            for (let i = 0; i < 10; i++) queue.enqueue(`item-${i}`);
+            queue.shiftByN(10);
+            expect(queue.getLength()).toBe(0);
+            expect(Object.keys((queue as unknown as { items: Record<string, unknown> }).items)).toHaveLength(0);
+        });
+    });
+
 });


### PR DESCRIPTION
`for...in Object.keys(this.items)` iterates the returned array's numeric  
  indices (0, 1, 2, ...), not the object's actual keys. Once `head` has                       
  advanced past the items bag's size — which happens any time `shift` has                     
  been called enough to drive the head forward — the delete loop targets                      
  non-existent keys and the real skipped entries remain attached to                           
  `this.items` indefinitely.                                                                  
                                                                                              
  The leak is proportional to single-shift vs shiftByN calls in the                           
  workload. In the block producer's mongoInsertQueue it surfaced as ~0.33   
  orphaned entries per block produced under backfill.                                         
                                                                                              
  Fix: `for...of`, so `key` iterates actual keys. Delete by numericKey for                    
  strict-mode type correctness against `Record<number, ...>`.                                 
                                                                                              
  Add regression tests covering the specific scenario (drive head past the                    
  bag size, then shiftByN) plus the straightforward return / empty-drain                      
  cases.