### PR TITLE
fix(block_subscription): discard malformed eth_subscribe log events

### DIFF
--- a/internal/block_subscription/abstract_block_subscription.ts
+++ b/internal/block_subscription/abstract_block_subscription.ts
@@ -20,6 +20,7 @@ import Long from "long";
  * @author - Vibhu Rajeev
  */
 export abstract class AbstractBlockSubscription extends Queue<IBlockGetterWorkerPromise> implements IBlockSubscription<IBlock, BlockProducerError> {
+    private static readonly ZERO_BLOCK_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000";
     private subscription: Subscription<Log> | null = null;
     // @ts-ignore 
     protected observer: IObserver<IBlock, BlockProducerError>; // ts-ignore added for this special case (it will always get initialized in the subscribe method).
@@ -113,6 +114,30 @@ export abstract class AbstractBlockSubscription extends Queue<IBlockGetterWorker
                             blockNumber: log.blockNumber,
                             logIndex: log.logIndex
                         });
+
+                        // Reject sentinel / malformed log events. A live `logs` subscription
+                        // only emits forward-progressing, confirmed blocks — anything with an
+                        // all-zero blockHash, a non-finite blockNumber, or a blockNumber at or
+                        // below the last received one is a poisoned payload that must not be
+                        // allowed to rewrite `lastReceivedBlockNumber` (see incident
+                        // 2026-04-21 amoy-producer checkpoint regression).
+                        if (
+                            !log.blockHash ||
+                            log.blockHash === AbstractBlockSubscription.ZERO_BLOCK_HASH ||
+                            typeof log.blockNumber !== "number" ||
+                            !Number.isFinite(log.blockNumber) ||
+                            log.blockNumber <= this.lastReceivedBlockNumber
+                        ) {
+                            Logger.warn({
+                                location: "eth_subscribe",
+                                message: "Discarding malformed log event",
+                                blockHash: log.blockHash,
+                                blockNumber: log.blockNumber,
+                                logIndex: log.logIndex,
+                                lastReceivedBlockNumber: this.lastReceivedBlockNumber
+                            });
+                            return;
+                        }
 
                         if (this.lastBlockHash == log.blockHash) {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maticnetwork/chain-indexer-framework",
-  "version": "1.4.20",
+  "version": "1.4.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maticnetwork/chain-indexer-framework",
-      "version": "1.4.20",
+      "version": "1.4.23",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maticnetwork/chain-indexer-framework",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "description": "blockchain data indexer",
   "type": "module",
   "exports": {

--- a/tests/block_subscription/abstract_block_subscription.test.ts
+++ b/tests/block_subscription/abstract_block_subscription.test.ts
@@ -250,6 +250,72 @@ describe("Abstract Block Subscription", () => {
             }, 100);
         });
 
+        test("Malformed log events (sentinel hash, non-finite or non-forward blockNumber) must be discarded without poisoning subscriber state.", (done) => {
+            // Regression test for the 2026-04-21 amoy-producer incident:
+            // a single malformed `eth_subscribe` log payload with
+            // blockHash = 0x000…0 and blockNumber = 0 advanced
+            // `lastReceivedBlockNumber` to 0, which then caused
+            // `hasMissedBlocks` to enqueue ~37M backfill jobs starting from 1.
+            expect.assertions(2);
+
+            mockedEthObject.getBlock.mockResolvedValueOnce({ number: 0 } as BlockTransactionObject);
+            subscriber.getBlockFromWorker.mockResolvedValueOnce(
+                { block: { ...fullEthereumBlock, number: mockNumber } as unknown as IBlock }
+            );
+            subscriber.getBlockFromWorker.mockResolvedValueOnce(
+                { block: { ...fullEthereumBlock, number: mockNumber } as unknown as IBlock }
+            );
+
+            mockNumber.toNumber.mockReturnValueOnce(100);
+            mockNumber.toNumber.mockReturnValueOnce(101);
+
+            subscriber.subscribe(observer, 100).then(() => {
+                // First valid log advances lastReceivedBlockNumber to 100.
+                on.mock.calls[0][1]({
+                    ...mockLog,
+                    blockHash: "0xrealhash100",
+                    blockNumber: 100
+                });
+
+                // Poisoned payloads that must all be discarded.
+                on.mock.calls[0][1]({
+                    ...mockLog,
+                    blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    blockNumber: 0,
+                    logIndex: 0
+                });
+                on.mock.calls[0][1]({
+                    ...mockLog,
+                    blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    blockNumber: 102,
+                    logIndex: 1
+                });
+                on.mock.calls[0][1]({
+                    ...mockLog,
+                    blockHash: "0xsomehash",
+                    blockNumber: 50,
+                    logIndex: 0
+                });
+
+                // Subsequent valid log must trigger only the small forward gap
+                // backfill (101) — not a poisoned 0..N catch-up.
+                on.mock.calls[0][1]({
+                    ...mockLog,
+                    blockHash: "0xrealhash102",
+                    blockNumber: 102
+                });
+            });
+
+            setTimeout(() => {
+                // Only the two real logs and the single missed block (101)
+                // should have been fetched — three total. None of the
+                // malformed payloads should reach the worker.
+                expect(subscriber.getBlockFromWorker).toBeCalledTimes(3);
+                expect(subscriber.getBlockFromWorker).not.toBeCalledWith(0);
+                done();
+            }, 100);
+        });
+
         test("On a re org being missed, subscription must call observer.error", (done) => {
             expect.assertions(1);
 


### PR DESCRIPTION
## Summary

Fixes the root cause of the [2026-04-21 amoy-producer checkpoint regression](https://github.com/0xPolygon/apps-team-ops/blob/main/docs/incidents/bridge-api-services/2026-04-21-amoy-producer-checkpoint-regression.md), where prod amoy-producer's checkpoint spontaneously dropped from block ~36,996,080 to ~0 with no operator action and no container restart, then began re-indexing the entire chain.

The `.on("data", ...)` handler in `AbstractBlockSubscription` trusted every log payload as authoritative without validation. A single malformed `eth_subscribe` log event from the WebSocket RPC subscription:

```json
{ "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "blockNumber": 0,
  "logIndex": 0 }
```

was accepted by the handler, which set `lastReceivedBlockNumber = 0` and enqueued `getBlockFromWorker(0)`. The next real log at block 36,996,082 then tripped `hasMissedBlocks` (`36996082 - 0 > 1`), and `enqueueMissedBlocks` queued ~37 million worker fetches for blocks 1…36,996,081.

The investigation in the incident report ruled out a decoding bug in `web3-providers-ws` / `web3-core-helpers` / `web3-eth` — the malformed payload was in the raw RPC frame. Sentinel-valued logs are a real RPC edge case the framework must defend against regardless of which provider produced it.

## Changes

- `internal/block_subscription/abstract_block_subscription.ts` — guard at the top of the `data` callback that discards any log event with a falsy or all-zero `blockHash`, a non-finite `blockNumber`, or a `blockNumber` at or below `lastReceivedBlockNumber`. A live `logs` subscription only ever emits forward-progressing, confirmed blocks; backwards motion is always a malformed payload, not a reorg (reorgs are detected later in `processQueue` via `parentHash`). Discarded events are logged at `warn` level for diagnostics.
- `tests/block_subscription/abstract_block_subscription.test.ts` — regression test that fires four malformed payloads (zero-hash + zero number, zero-hash + valid number, valid hash + backwards number, plus the recovery sequence) and verifies that none reach the worker pool and that subsequent valid logs only trigger the small forward-gap backfill.
- `package.json` / `package-lock.json` — manual patch bump `1.4.22 → 1.4.23` to publish the fix.

## Test plan

- [ ] CI passes
- [ ] After release, bump `@maticnetwork/chain-indexer-framework` in `bridge-api-services` amoy and pos producers (rest will follow)
- [ ] Verify normal amoy-producer operation for ≥24h post-deploy

## Notes for reviewer

- **Existing test suite is broken at HEAD** — the 17 pre-existing tests in `abstract_block_subscription.test.ts` all fail today due to a jest 30 / `@types/jest@30` upgrade mismatch (`toBeCalled` was renamed to `toHaveBeenCalled`). The new regression test deliberately matches the existing pattern so it gets fixed alongside the rest in a separate cleanup PR. Happy to switch only the new test to the new API if preferred.
- **`lint` script is also broken at HEAD** — ESLint 9 needs `eslint.config.js` migration; pre-existing.
- The guard is intentionally placed **before** the existing `lastBlockHash == log.blockHash` dedupe check. In the prod incident, after the poison log set `lastBlockHash = 0x0000…`, the subsequent real logs at block 36,996,080 with `blockHash = 0x0000…` would have been short-circuited by the dedupe — the new guard catches them via the sentinel-hash check instead.
