### PR TITLE
fix(block_subscription): allow same-block / different-logIndex events through guard

### DIFF
--- a/internal/block_subscription/abstract_block_subscription.ts
+++ b/internal/block_subscription/abstract_block_subscription.ts
@@ -117,16 +117,22 @@ export abstract class AbstractBlockSubscription extends Queue<IBlockGetterWorker
 
                         // Reject sentinel / malformed log events. A live `logs` subscription
                         // only emits forward-progressing, confirmed blocks — anything with an
-                        // all-zero blockHash, a non-finite blockNumber, or a blockNumber at or
+                        // all-zero blockHash, a non-finite blockNumber, or a blockNumber strictly
                         // below the last received one is a poisoned payload that must not be
                         // allowed to rewrite `lastReceivedBlockNumber` (see incident
                         // 2026-04-21 amoy-producer checkpoint regression).
+                        //
+                        // Note `<` not `<=`: a single block contains many transactions emitting
+                        // many logs, all sharing the same blockNumber but different logIndex
+                        // values. Those duplicates are normal and are filtered out by the
+                        // `lastBlockHash == log.blockHash` dedupe a few lines below — they must
+                        // not be flagged as malformed here.
                         if (
                             !log.blockHash ||
                             log.blockHash === AbstractBlockSubscription.ZERO_BLOCK_HASH ||
                             typeof log.blockNumber !== "number" ||
                             !Number.isFinite(log.blockNumber) ||
-                            log.blockNumber <= this.lastReceivedBlockNumber
+                            log.blockNumber < this.lastReceivedBlockNumber
                         ) {
                             Logger.warn({
                                 location: "eth_subscribe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maticnetwork/chain-indexer-framework",
-  "version": "1.4.23",
+  "version": "1.4.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maticnetwork/chain-indexer-framework",
-      "version": "1.4.23",
+      "version": "1.4.24",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maticnetwork/chain-indexer-framework",
-  "version": "1.4.23",
+  "version": "1.4.24",
   "description": "blockchain data indexer",
   "type": "module",
   "exports": {

--- a/tests/block_subscription/abstract_block_subscription.test.ts
+++ b/tests/block_subscription/abstract_block_subscription.test.ts
@@ -250,12 +250,16 @@ describe("Abstract Block Subscription", () => {
             }, 100);
         });
 
-        test("Malformed log events (sentinel hash, non-finite or non-forward blockNumber) must be discarded without poisoning subscriber state.", (done) => {
+        test("Malformed log events (sentinel hash, non-finite or backwards blockNumber) must be discarded without poisoning subscriber state.", (done) => {
             // Regression test for the 2026-04-21 amoy-producer incident:
             // a single malformed `eth_subscribe` log payload with
             // blockHash = 0x000…0 and blockNumber = 0 advanced
             // `lastReceivedBlockNumber` to 0, which then caused
             // `hasMissedBlocks` to enqueue ~37M backfill jobs starting from 1.
+            //
+            // Also asserts the guard does NOT discard same-block / different-logIndex
+            // duplicates — those are normal Ethereum behaviour (one block has many
+            // logs) and must fall through to the existing lastBlockHash dedupe.
             expect.assertions(2);
 
             mockedEthObject.getBlock.mockResolvedValueOnce({ number: 0 } as BlockTransactionObject);
@@ -274,7 +278,23 @@ describe("Abstract Block Subscription", () => {
                 on.mock.calls[0][1]({
                     ...mockLog,
                     blockHash: "0xrealhash100",
-                    blockNumber: 100
+                    blockNumber: 100,
+                    logIndex: 0
+                });
+
+                // Same block, additional logIndexes — normal duplicates.
+                // Must be silently deduped via lastBlockHash, NOT flagged as malformed.
+                on.mock.calls[0][1]({
+                    ...mockLog,
+                    blockHash: "0xrealhash100",
+                    blockNumber: 100,
+                    logIndex: 1
+                });
+                on.mock.calls[0][1]({
+                    ...mockLog,
+                    blockHash: "0xrealhash100",
+                    blockNumber: 100,
+                    logIndex: 2
                 });
 
                 // Poisoned payloads that must all be discarded.
@@ -302,14 +322,15 @@ describe("Abstract Block Subscription", () => {
                 on.mock.calls[0][1]({
                     ...mockLog,
                     blockHash: "0xrealhash102",
-                    blockNumber: 102
+                    blockNumber: 102,
+                    logIndex: 0
                 });
             });
 
             setTimeout(() => {
-                // Only the two real logs and the single missed block (101)
-                // should have been fetched — three total. None of the
-                // malformed payloads should reach the worker.
+                // Only the two real blocks (100, 102) and the single missed block (101)
+                // should have been fetched — three total. None of the malformed
+                // payloads, and none of the same-block duplicates, should reach the worker.
                 expect(subscriber.getBlockFromWorker).toBeCalledTimes(3);
                 expect(subscriber.getBlockFromWorker).not.toBeCalledWith(0);
                 done();


### PR DESCRIPTION
## Summary

Follow-up to [PR #82](https://github.com/0xPolygon/chain-indexer-framework/pull/82). The malformed-log-event guard added in 1.4.23 used `<=` when comparing `log.blockNumber` to `lastReceivedBlockNumber`, which falsely flagged every log past the first one in a block (logIndex 1, 2, 3, …) as malformed.

A single Ethereum block typically contains many transactions emitting many logs — they all share the same `blockNumber` and `blockHash`, only `logIndex` differs. Those duplicates are normal and were already filtered out one statement later by the existing `lastBlockHash == log.blockHash` dedupe. The malformed guard fired *first* and produced misleading warn-level lines like:

```
warn: Discarding malformed log event,
  blockHash: 0x279ee4ce…, blockNumber: 37362269, logIndex: 1,
  lastReceivedBlockNumber: 37362269
```

There is no functional regression — the duplicates were always going to be deduped; the framework only ever fetches one block per `blockNumber` from the worker pool — but the noise pollutes Datadog and dilutes the real malformed-payload signal we want to alert on.

## Change

`abstract_block_subscription.ts` — comparison changed from `<=` to `<`:

```diff
- log.blockNumber <= this.lastReceivedBlockNumber
+ log.blockNumber <  this.lastReceivedBlockNumber
```

Cases under the new check:

| Scenario | blockNumber | lastReceived | `<` check | Outcome |
|---|---|---|---|---|
| Original poison case (incident) | 0 | 36,996,078 | true | rejected ✓ |
| Any other backwards motion | N | M (N<M) | true | rejected ✓ |
| Same block, different logIndex | N | N | false | passes guard, dedupe'd by hash ✓ |
| New forward block | N+1 | N | false | passes guard, processed ✓ |

## Test

The existing regression test is extended to fire two same-block-different-logIndex payloads after the first valid log of a block, and asserts:

- `getBlockFromWorker` is called exactly 3 times (only for the two real *blocks* and the single missed block)
- It is never called with `0` (the poison case)

So the same-block duplicates neither reach the worker pool nor get flagged as malformed.

## Test plan

- [ ] CI passes
- [ ] After release, bump `@maticnetwork/chain-indexer-framework` 1.4.23 → 1.4.24 in amoy + pos producers
- [ ] Confirm no more `Discarding malformed log event` warns for valid same-block logs in Datadog
