### PR TITLE
fix: surface underlying RPC error cause in block producer error messages

### DIFF
--- a/internal/block_getters/block_getter.ts
+++ b/internal/block_getters/block_getter.ts
@@ -102,11 +102,12 @@ export class BlockGetter extends BlockFormatter implements IBlockGetter {
             return this.formatBlockWithTransactions(block, transactions);
         } catch (error) {
             if (!(error instanceof BlockProducerError)) {
+                const cause = error instanceof Error ? error.message : JSON.stringify(error);
                 throw new BlockProducerError(
                     "Block producer error on getBlockWithTransactions",
                     BlockProducerError.codes.RPC_ERR,
                     true,
-                    JSON.stringify(error),
+                    `Error fetching block ${blockNumber} with receipts: ${cause}`,
                     "remote"
                 );
             }
@@ -184,11 +185,12 @@ export class BlockGetter extends BlockFormatter implements IBlockGetter {
             return this.formatTransactionReceipt(transactionReceipt);
         } catch (error) {
             if (!(error instanceof BlockProducerError)) {
+                const cause = error instanceof Error ? error.message : JSON.stringify(error);
                 throw new BlockProducerError(
                     "Block producer error on transaction receipt",
                     BlockProducerError.codes.RPC_ERR,
                     true,
-                    JSON.stringify(error),
+                    `Error fetching receipt for ${transactionHash}: ${cause}`,
                     "remote"
                 );
             }

--- a/internal/block_producers/block_producer.ts
+++ b/internal/block_producers/block_producer.ts
@@ -342,11 +342,12 @@ export class BlockProducer extends AsynchronousProducer {
             } catch (error) {
                 let err = error;
                 if (!(err instanceof BlockProducerError)) {
+                    const cause = error instanceof Error ? error.message : JSON.stringify(error);
                     err = new BlockProducerError(
                         "Remote block fetch error",
                         BlockProducerError.codes.RPC_ERR,
                         true,
-                        "Error fetching remote block in getStartBlock",
+                        `Error fetching block ${blockNumber} in getStartBlock: ${cause}`,
                         "remote"
                     );
                 }


### PR DESCRIPTION
## Summary

- `getStartBlock` was wrapping any non-`BlockProducerError` in a new error with a generic message, silently discarding the original RPC error (auth failure, network error, timeout, etc.)
- `getBlockWithTransactionReceipts` and `getTransactionReceipt` used `JSON.stringify(error)` which misses `Error.message` since it is non-enumerable — underlying RPC error text was dropped
- All three now include the block number / tx hash and the original `error.message` in the logged message

## Motivation

During a production incident today, the ethereum-producer crash-looped with:
```
Error fetching remote block in getStartBlock : {"name":"Remote block fetch error","code":4004,"isFatal":true,"origin":"remote","identifier":100}
```
The actual RPC failure was completely hidden. With this fix the log would instead read something like:
```
Error fetching block 25251475 in getStartBlock: 503 Service Unavailable
```
making the root cause immediately actionable without needing cluster access.

## Test plan

- [ ] Verify existing tests pass
- [ ] Manually confirm error messages include the original cause in a local run against a broken RPC endpoint