### PR TITLE
feat(block-producer): log successful block persistence to mongo, release 1.4.26

### DIFF
--- a/internal/block_producers/block_producer.ts
+++ b/internal/block_producers/block_producer.ts
@@ -300,6 +300,21 @@ export class BlockProducer extends AsynchronousProducer {
                 details,
                 this.maxReOrgDepth
             );
+
+            // Only success-path signal for this write. "Delivery-report:" (in the
+            // "delivered" handler above) fires on every Kafka ack, well before this
+            // point, and does not confirm persistence — investigating a stalled
+            // checkpoint previously had no way to tell "queue backed up" from
+            // "the DB write itself is failing/retrying" without this line.
+            Logger.info({
+                location: "block_producer",
+                function: "addBlockToMongo",
+                status: "block persisted",
+                data: {
+                    blockNumber: details.number,
+                    retryCount
+                }
+            });
         } catch (error) {
             // Tries upto 5 times to add transaction.
             if (retryCount < 4) {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,4 @@
-import { JestConfigWithTsJest } from "ts-jest";
+import type { JestConfigWithTsJest } from "ts-jest";
 
 const jestConfig: JestConfigWithTsJest = {
     "transform": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maticnetwork/chain-indexer-framework",
-  "version": "1.4.25",
+  "version": "1.4.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maticnetwork/chain-indexer-framework",
-      "version": "1.4.25",
+      "version": "1.4.26",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maticnetwork/chain-indexer-framework",
-  "version": "1.4.25",
+  "version": "1.4.26",
   "description": "blockchain data indexer",
   "type": "module",
   "exports": {

--- a/tests/block_producer/block_producer.test.ts
+++ b/tests/block_producer/block_producer.test.ts
@@ -451,7 +451,7 @@ describe("Block Producer", () => {
             });
 
             test("On delivery report, the produced block must be added to mongoDB collection in correct order", (done) => {
-                expect.assertions(3);
+                expect.assertions(5);
                 mockedAsynchronousProducerObject.produceEvent.mockRejectedValueOnce({ isFatal: true });
                 //Mock implementation to change order.
                 mockedProducedBlockModel.add.mockImplementationOnce(async () => {
@@ -512,6 +512,24 @@ describe("Block Producer", () => {
                                 },
                                 0
                             );
+                            expect(mockedLogger.info).toHaveBeenCalledWith({
+                                location: "block_producer",
+                                function: "addBlockToMongo",
+                                status: "block persisted",
+                                data: {
+                                    blockNumber: 15400000,
+                                    retryCount: 0
+                                }
+                            });
+                            expect(mockedLogger.info).toHaveBeenCalledWith({
+                                location: "block_producer",
+                                function: "addBlockToMongo",
+                                status: "block persisted",
+                                data: {
+                                    blockNumber: 15400001,
+                                    retryCount: 0
+                                }
+                            });
                             done();
                         } catch (error) {
                             //Catch to log the test failure.
@@ -558,6 +576,9 @@ describe("Block Producer", () => {
                 expect(mockedLogger.error).toBeCalledTimes(1);
                 expect(mockedLogger.error).toBeCalledWith(
                     BlockProducerError.createUnknown(new Error("Demo"))
+                );
+                expect(mockedLogger.info).not.toHaveBeenCalledWith(
+                    expect.objectContaining({ status: "block persisted" })
                 );
             });
         });

--- a/tests/block_producer/block_producer.test.ts
+++ b/tests/block_producer/block_producer.test.ts
@@ -572,9 +572,9 @@ describe("Block Producer", () => {
                     resolve(true);
                 }, 100));
 
-                expect(mockedProducedBlockModel.add).toBeCalledTimes(5);
-                expect(mockedLogger.error).toBeCalledTimes(1);
-                expect(mockedLogger.error).toBeCalledWith(
+                expect(mockedProducedBlockModel.add).toHaveBeenCalledTimes(5);
+                expect(mockedLogger.error).toHaveBeenCalledTimes(1);
+                expect(mockedLogger.error).toHaveBeenCalledWith(
                     BlockProducerError.createUnknown(new Error("Demo"))
                 );
                 expect(mockedLogger.info).not.toHaveBeenCalledWith(


### PR DESCRIPTION
## Why

Investigating a katana `/chainsync` false-CRITICAL alert (bridge-api-services incident, 2026-07-15) relied on the producer's `producedblocks_<chain>` checkpoint being "stalled" as key evidence. The only candidate log signal on that path — `"Delivery-report:"` in the `"delivered"` handler above `addBlockToMongo` — fires on every Kafka delivery ack, **before** persistence, not after. It confirms the broker accepted the message, not that MongoDB was actually updated.

`addBlockToMongo` itself has **no success-path log at all** — only `Logger.error` after all 5 retries are exhausted. This means there was no way to distinguish, after the fact: "the in-memory `mongoInsertQueue` backed up" vs. "the DB write itself was failing and silently retrying" vs. "everything is fine and just idle." That gap made the katana investigation's producer-side claims unverifiable from logs alone — checked in detail; happy to share the specifics if useful context.

## Change

One log line, added after the write succeeds in `addBlockToMongo` (`internal/block_producers/block_producer.ts`):

```ts
Logger.info({
    location: "block_producer",
    function: "addBlockToMongo",
    status: "block persisted",
    data: { blockNumber: details.number, retryCount }
});
```

Matches the existing `{location, function, status, data}` shape already used elsewhere in this file (e.g. `"Producer started"`). Includes `retryCount` so a write that only succeeded after retries is visible, not just silently masked as instant success.

No behavior change — the try/catch, retry logic (up to 4 retries, throw on the 5th failure), and `processQueue`'s `shift()`/`shiftByN()` batching logic are all untouched.

## Also fixes: `jest.config.ts`

```diff
-import { JestConfigWithTsJest } from "ts-jest";
+import type { JestConfigWithTsJest } from "ts-jest";
```

`JestConfigWithTsJest` is a type-only export in `ts-jest`. Without `import type`, Jest's config loader (at least under Node 24, which does its own type-erasure rather than full type-checking) tries to resolve it as a real value export and fails outright with `SyntaxError: The requested module 'ts-jest' does not provide an export named 'JestConfigWithTsJest'` — meaning **the entire test suite could not run at all** before this fix, independent of anything else in this PR. Needed this fixed just to verify my own change; bundling it since it's a one-line, zero-risk type-only annotation.

## Test plan

- `npm run build` (`tsc && tsc-alias && npm run copy-proto`) — clean.
- **Actually executed, under Node 20** (this machine's default Node 24 cannot compile `node-rdkafka`'s native binding at all — `nan`-based, predates C++20, fails against Node 24's V8 headers with `std::ranges`/`concept`/`requires` errors; confirmed unrelated to this change via a fresh lockfile-accurate `npm ci` hitting the identical failure under Node 24. Node 20 compiles it fine):
  - `npm ci && npm run build && npx jest tests/block_producer/block_producer.test.ts`
  - **"On delivery report, the produced block must be added to mongoDB collection in correct order" — PASSES.** Confirms `Logger.info` fires with the exact `{location, function, status: "block persisted", data: {blockNumber, retryCount: 0}}` shape for each successfully-persisted block.
  - **"On error when adding produced block to mongoDB..." — PASSES.** Confirms `Logger.info` is never called with `status: "block persisted"` when every retry fails (only `Logger.error` fires, as before).
- **13 other, pre-existing tests in this same file fail**, all on the identical root cause: `toBeCalledWith`/`toBeCalledTimes` were removed as matcher aliases in Jest 30 (this repo's pinned version), and nothing in the test file was updated when Jest was bumped. None of these 13 are in test blocks this PR touches — confirmed by fixing the *one* occurrence of this pattern that happened to sit inside a test I already had assertions in (blocking verification of my own new assertion there), while leaving the other 13 alone. Recommend a dedicated follow-up PR to fix the rest — happy to open one if wanted, kept it out of this PR to stay scoped to the logging change.

## Release: 1.4.25 → 1.4.26

This repo has no CI publish step, so releases are cut manually. Bundled the version bump into this same branch/PR (matching the exact `chore(release): 1.4.26` commit style of the prior `1.4.25` release commit — `package.json` + `package-lock.json` only, no other files, no git tag). `1.4.25` is confirmed live as npm's current `latest` dist-tag, so `1.4.26` is the correct next patch.

Sequencing for this one: `npm publish` runs locally against this branch **before** merge (so `main` never sits ahead of what's actually published), then this PR merges to `main` once the publish is confirmed.

https://claude.ai/code/session_01BvVwfYzChywzuYAk1SQ6Ln

