### PR TITLE
fix(mongo): add connection timeouts to prevent silent write hangs

### DIFF
--- a/internal/mongo/database.ts
+++ b/internal/mongo/database.ts
@@ -33,7 +33,17 @@ export class Database {
      */
     public async connect(): Promise<boolean> {
         if (!(this.database.connection.readyState === 1 || this.database.connection.readyState === 2)) {
-            await this.database.connect(this.url);
+            await this.database.connect(this.url, {
+                // Without these, an in-flight write whose server never responds hangs
+                // indefinitely (the driver's default socketTimeoutMS is unlimited),
+                // silently freezing the producer's persistence checkpoint until a process
+                // restart. Bounding them turns the hang into a thrown, logged error that
+                // the retry/restart path can recover from. See incidents 2026-07-15
+                // (katana-producer) and 2026-08-14 (ethereum-producer).
+                serverSelectionTimeoutMS: 30000,
+                connectTimeoutMS: 30000,
+                socketTimeoutMS: 60000,
+            });
         }
 
         return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maticnetwork/chain-indexer-framework",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "description": "blockchain data indexer",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Problem

The Mongoose connection in `Database.connect()` is opened with no timeout options. Under a specific failure mode, an in-flight MongoDB write whose server never responds hangs **indefinitely** — the driver's default `socketTimeoutMS` is effectively unlimited. This silently freezes the producer's `producedblocks_<chain>` persistence checkpoint with zero errors logged. Only a process restart clears it.

This has now caused two production incidents on `bridge-api-services`:
- 2026-07-15 — katana-producer
- 2026-08-14 — ethereum-producer

This fix was the top open follow-up from the July post-mortem, and it has now recurred.

## Fix

Pass explicit bounded timeouts to `mongoose.connect()`:

- `serverSelectionTimeoutMS: 30000`
- `connectTimeoutMS: 30000`
- `socketTimeoutMS: 60000`

This turns the silent indefinite hang into a thrown, logged error, letting the process's own retry/restart logic recover instead of requiring a manual restart.

## Scope

`public/mongo/database.ts` only re-exports from `internal/mongo/database.ts` (no separate implementation), so only the internal file needed the change.

## Verification

- `npm run build` — passes (option names typecheck against the installed `mongoose@^6.13.6` types)
- `npm run lint` — pre-existing, unrelated failure: this repo's `package.json` pins `eslint@^9.39.1` but ships a legacy `.eslintrc.yaml` with no `eslint.config.js`; ESLint 9 requires flat config. Confirmed broken on unmodified `origin/main` too.
- `npm run tests` — ran to completion (~41s, did not hang); 121 pre-existing failures across 22 suites, all unrelated to this change (e.g. `abstract_block_subscription.test.ts`). No test file exercises `internal/mongo/database.ts` directly.
- `npm install` required Node 20 — Node 24 fails building the `node-rdkafka` native module against this repo's toolchain (pre-existing environment issue, unrelated to this change; repo's own CI pins Node 18).

https://claude.ai/code/session_01Pznxd3hn96ppZSQU1zBizr